### PR TITLE
Fix duplicate loginForm declaration

### DIFF
--- a/frontend/src/components/AuthPage.tsx
+++ b/frontend/src/components/AuthPage.tsx
@@ -84,7 +84,7 @@ const AuthPage: React.FC = () => {
     }
   };
 
-  const loginForm = (
+  const loginFormElement = (
     <Form
       form={loginForm}
       name="login"
@@ -133,7 +133,7 @@ const AuthPage: React.FC = () => {
     </Form>
   );
 
-  const registerForm = (
+  const registerFormElement = (
     <Form
       form={registerForm}
       name="register"
@@ -271,12 +271,12 @@ const AuthPage: React.FC = () => {
     {
       key: 'login',
       label: 'Sign In',
-      children: loginForm,
+      children: loginFormElement,
     },
     {
       key: 'register',
       label: 'Sign Up',
-      children: registerForm,
+      children: registerFormElement,
     },
   ];
 


### PR DESCRIPTION
Rename `loginForm` and `registerForm` JSX elements to resolve identifier re-declaration errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-548d4c9e-cefe-412c-b382-d9ddf7f949ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-548d4c9e-cefe-412c-b382-d9ddf7f949ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>